### PR TITLE
add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine
 MAINTAINER admin@acale.ph
 
+RUN apk add --update ca-certificates
+
 ADD build/bin/rudder /usr/local/bin/rudder
 ADD third-party/swagger /opt/rudder/swagger
 


### PR DESCRIPTION
fix error: x509: failed to load system roots and no roots provided