### PR TITLE
PUT /api/v1/releases/NAME to update a release

### DIFF
--- a/cmd/rudder.go
+++ b/cmd/rudder.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/AcalephStorage/go-auth"
+	auth "github.com/AcalephStorage/go-auth"
 	log "github.com/Sirupsen/logrus"
 	"github.com/emicklei/go-restful"
 	restfullog "github.com/emicklei/go-restful/log"

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 6c7cf67bb1a94666919774af4d03f084a9f019548174b72d2f5ce7e2b2a574ee
-updated: 2016-12-08T15:33:29.131818972+08:00
+hash: 6192beab0887a4287fa923ec44dd8efd53ea9edb3f07aeb9ac7ba9d375201756
+updated: 2018-02-26T11:31:08.834851571Z
 imports:
 - name: github.com/AcalephStorage/go-auth
   version: a94da01afb9889ea6537e78aa6a7c0bfac1f197d
+- name: github.com/BurntSushi/toml
+  version: b26d9c308763d68093482582cea63d69be07a0f0
 - name: github.com/coreos/go-oidc
   version: 8472879a4fc0182e34ed1a1edf711625a9c9fab2
 - name: github.com/emicklei/go-restful
@@ -12,20 +14,34 @@ imports:
   - swagger
 - name: github.com/ghodss/yaml
   version: a54de18a07046d8c4b26e9327698a2ebb9285b36
+- name: github.com/gobwas/glob
+  version: 5ccd90ef52e1e632236f7326478d4faa74f99438
+  subpackages:
+  - compiler
+  - match
+  - syntax
+  - syntax/ast
+  - syntax/lexer
+  - util/runes
+  - util/strings
 - name: github.com/golang/protobuf
-  version: df1d3ca07d2d07bba352d5b73c4313b4e2a6203e
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - proto
+  - ptypes
   - ptypes/any
+  - ptypes/duration
   - ptypes/timestamp
 - name: github.com/Masterminds/semver
-  version: 808ed7761c233af2de3f9729a041d68c62527f3a
+  version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd
 - name: github.com/pquerna/cachecontrol
   version: c97913dcbd76de40b051a9b4cd827f7eaeb7a868
   subpackages:
   - cacheobject
 - name: github.com/Sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
+- name: github.com/spf13/pflag
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/urfave/cli
   version: a14d7d367bc02b1f57d88de97926727f2d936387
 - name: golang.org/x/crypto
@@ -40,13 +56,15 @@ imports:
   - openpgp/packet
   - openpgp/s2k
 - name: golang.org/x/net
-  version: fb93926129b8ec0056f2f458b1f519654814edf0
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - context
   - context/ctxhttp
   - http2
   - http2/hpack
+  - idna
   - internal/timeseries
+  - lex/httplex
   - trace
 - name: golang.org/x/oauth2
   version: d5040cddfc0da40b408c9a1da4728662435176a9
@@ -56,6 +74,13 @@ imports:
   version: c200b10b5d5e122be351b67af224adc6128af5bf
   subpackages:
   - unix
+- name: golang.org/x/text
+  version: b19bf474d317b857955b12035d2c5acb57ce8b01
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
 - name: google.golang.org/appengine
   version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
   subpackages:
@@ -66,16 +91,24 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
+- name: google.golang.org/genproto
+  version: 2b5a72b8730b0b16380010cfe5286c42108d88e7
+  subpackages:
+  - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 0032a855ba5c8a3c8e0d71c2deef354b70af1584
+  version: 5ffe3083946d5603a0578721101dc8165b1d5b5f
   subpackages:
   - codes
   - credentials
   - grpclog
   - internal
+  - keepalive
   - metadata
   - naming
   - peer
+  - stats
+  - status
+  - tap
   - transport
 - name: gopkg.in/square/go-jose.v2
   version: 296c7f1463ec9b712176dc804dea0173d06dc728
@@ -84,17 +117,32 @@ imports:
   - json
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+- name: k8s.io/apimachinery
+  version: cced8e64b6ca92a8b6afcbfea3353ca016694a45
+  subpackages:
+  - pkg/version
+- name: k8s.io/client-go
+  version: e00c8f23c00e0935e9abf285596fe76f0b63c040
+  subpackages:
+  - util/homedir
 - name: k8s.io/helm
-  version: dc87ea8dd0111164c720fd13b4eb8a905f97ac62
+  version: 6af75a8fd72e2aa18a2b278cfe5c7a1c5feca7f2
   subpackages:
   - pkg/chartutil
+  - pkg/getter
   - pkg/helm
+  - pkg/helm/environment
+  - pkg/helm/helmpath
   - pkg/ignore
+  - pkg/plugin
   - pkg/proto/hapi/chart
   - pkg/proto/hapi/release
   - pkg/proto/hapi/services
   - pkg/proto/hapi/version
   - pkg/provenance
   - pkg/repo
+  - pkg/sympath
+  - pkg/tlsutil
+  - pkg/urlutil
   - pkg/version
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/Sirupsen/logrus
   version: ~0.10.0
 - package: k8s.io/helm
-  version: 2.0.1
+  version: 2.8.1
   subpackages:
   - pkg/chartutil
   - pkg/helm
@@ -20,11 +20,11 @@ import:
   version: ~1.18.1
 - package: github.com/ghodss/yaml
 - package: google.golang.org/grpc
-  version: v1.0.1-GA
 - package: github.com/coreos/go-oidc
 - package: golang.org/x/net
   subpackages:
   - context
+- package: golang.org/x/text/secure/bidirule
 - package: gopkg.in/square/go-jose.v2
   version: ~2.0.1
 - package: github.com/AcalephStorage/go-auth

--- a/internal/client/tiller-client.go
+++ b/internal/client/tiller-client.go
@@ -18,7 +18,7 @@ type TillerClient struct {
 // NewTillerClient creates a new TillerClient instance
 func NewTillerClient(address string) *TillerClient {
 	md := metadata.Pairs("x-helm-api-client", version.Version)
-	ctx := metadata.NewContext(context.TODO(), md)
+	ctx := metadata.NewOutgoingContext(context.TODO(), md)
 	return &TillerClient{address: address, context: ctx}
 }
 

--- a/internal/client/tiller-client.go
+++ b/internal/client/tiller-client.go
@@ -59,6 +59,17 @@ func (tc *TillerClient) InstallRelease(req *tiller.InstallReleaseRequest) (res *
 	return
 }
 
+// UpdateRelease updates an existing release
+func (tc *TillerClient) UpdateRelease(req *tiller.UpdateReleaseRequest) (res *tiller.UpdateReleaseResponse, err error) {
+	tc.execute(func(rsc tiller.ReleaseServiceClient) {
+		res, err = rsc.UpdateRelease(tc.context, req)
+		if err != nil {
+			log.Debug("unable to install release")
+		}
+	})
+	return
+}
+
 // UninstallRelease uninstalls a release
 func (tc *TillerClient) UninstallRelease(req *tiller.UninstallReleaseRequest) (res *tiller.UninstallReleaseResponse, err error) {
 	tc.execute(func(rsc tiller.ReleaseServiceClient) {

--- a/internal/controller/release.go
+++ b/internal/controller/release.go
@@ -8,6 +8,7 @@ import (
 	tiller "k8s.io/helm/pkg/proto/hapi/services"
 
 	"fmt"
+
 	"github.com/AcalephStorage/rudder/internal/client"
 )
 
@@ -77,6 +78,46 @@ func (rc *ReleaseController) InstallRelease(name, namespace, repo, chart, versio
 	res, err := rc.tillerClient.InstallRelease(req)
 	if err != nil {
 		log.WithError(err).Error("unable to install new release")
+		return nil, err
+	}
+	return res, nil
+}
+
+// UpdateRelease updates an existing release of the provided chart
+func (rc *ReleaseController) UpdateRelease(name, repo, chart, version string, values map[string]interface{}) (*tiller.UpdateReleaseResponse, error) {
+	chartDetails, err := rc.repoController.ChartDetails(repo, chart, version)
+	if err != nil {
+		log.WithError(err).Error("unable to get chart details")
+		return nil, err
+	}
+	tarball := chartDetails.ChartFile
+
+	inChart, err := chartutil.LoadFile(tarball)
+	if err != nil {
+		log.WithError(err).Error("unable to load chart details")
+		return nil, err
+	}
+	raw, _ := yaml.Marshal(values)
+
+	inValues := make(map[string]*hapi_chart.Value)
+	for k, v := range values {
+		inValues[k] = &hapi_chart.Value{Value: fmt.Sprintf("%v", v)}
+	}
+
+	config := &hapi_chart.Config{
+		Raw:    string(raw),
+		Values: inValues,
+	}
+
+	req := &tiller.UpdateReleaseRequest{
+		Name:   name,
+		Chart:  inChart,
+		Values: config,
+	}
+
+	res, err := rc.tillerClient.UpdateRelease(req)
+	if err != nil {
+		log.WithError(err).Error("unable to update release")
 		return nil, err
 	}
 	return res, nil

--- a/internal/resource/common.go
+++ b/internal/resource/common.go
@@ -13,9 +13,9 @@ var (
 )
 
 // errorResponse creates an error response from the given error
-func errorResponse(res *restful.Response, err restful.ServiceError) {
-	log.WithError(err).Error(err.Message)
+func errorResponse(origErr error, res *restful.Response, err restful.ServiceError) {
+	log.WithError(origErr).Error(err.Message)
 	if err := res.WriteServiceError(err.Code, err); err != nil {
-		log.WithError(err).Error("unable to write error")
+		log.WithError(origErr).Error("unable to write error")
 	}
 }

--- a/internal/resource/repo.go
+++ b/internal/resource/repo.go
@@ -75,7 +75,7 @@ func (rr *RepoResource) listRepos(req *restful.Request, res *restful.Response) {
 	log.Info("Getting list of helm repositories...")
 	repos := rr.controller.ListRepos()
 	if err := res.WriteEntity(repos); err != nil {
-		errorResponse(res, errFailToWriteResponse)
+		errorResponse(err, res, errFailToWriteResponse)
 	}
 }
 
@@ -86,12 +86,12 @@ func (rr *RepoResource) listCharts(req *restful.Request, res *restful.Response) 
 
 	charts, err := rr.controller.ListCharts(repoName, filter)
 	if err != nil {
-		errorResponse(res, errFailToGetCharts)
+		errorResponse(err, res, errFailToGetCharts)
 		return
 	}
 	// output
 	if err := res.WriteEntity(charts); err != nil {
-		errorResponse(res, errFailToWriteResponse)
+		errorResponse(err, res, errFailToWriteResponse)
 	}
 }
 
@@ -102,13 +102,13 @@ func (rr *RepoResource) listVersions(req *restful.Request, res *restful.Response
 
 	charts, err := rr.controller.ListCharts(repoName, chartName)
 	if err != nil {
-		errorResponse(res, errFailToListVersions)
+		errorResponse(err, res, errFailToListVersions)
 		return
 	}
 
 	versions := charts[chartName]
 	if err := res.WriteEntity(versions); err != nil {
-		errorResponse(res, errFailToWriteResponse)
+		errorResponse(err, res, errFailToWriteResponse)
 	}
 
 }
@@ -121,11 +121,11 @@ func (rr *RepoResource) getChart(req *restful.Request, res *restful.Response) {
 
 	chartDetail, err := rr.controller.ChartDetails(repoName, chartName, chartVersion)
 	if err != nil {
-		errorResponse(res, errFailToGetChartDetail)
+		errorResponse(err, res, errFailToGetChartDetail)
 		return
 	}
 
 	if err := res.WriteEntity(chartDetail); err != nil {
-		errorResponse(res, errFailToWriteResponse)
+		errorResponse(err, res, errFailToWriteResponse)
 	}
 }

--- a/rudder
+++ b/rudder
@@ -1,0 +1,1 @@
+/Users/peterbroadhurst/dev/photic/rudder


### PR DESCRIPTION
We needed to be able to update releases after they are deployed, so have added in the `updateRelease` capability that was a TODO in the code.

Also updated the error logging logic to include the original error that came back from Tiller, as this wasn't previously logged.

I'm submitting it back in case it is useful to others.

Note this branch builds on https://github.com/AcalephStorage/rudder/pull/16 (update to recent Helm/Tiller gRPC client level)